### PR TITLE
定时回收队列会有错误,应该添加对应的标记

### DIFF
--- a/src/Pool/AbstractPool.php
+++ b/src/Pool/AbstractPool.php
@@ -160,6 +160,7 @@ abstract class AbstractPool
                     if (time() - $obj->last_recycle_time > $idleTime) {
                         $this->unsetObj($obj);
                     } else {
+                        $this->objHash[$obj->__objectHash] = false;
                         array_push($list, $obj);
                     }
                 }


### PR DESCRIPTION
自定义进程中使用协程redis时,总是报连接池被耗空,查找源代码,发现回收连接池这个方法中(gcObject)应该添加标记,才能实现