### PR TITLE
使easyswoole/component支持winOS

### DIFF
--- a/src/Process/AbstractProcess.php
+++ b/src/Process/AbstractProcess.php
@@ -93,7 +93,7 @@ abstract class AbstractProcess
         Coroutine::create(function (){
 
         });
-        if(PHP_OS != 'Darwin' && !empty($this->getProcessName())){
+        if(!in_array(PHP_OS,['Darwin','CYGWIN','WINNT']) && !empty($this->getProcessName())){
             $process->name($this->getProcessName());
         }
         swoole_event_add($this->swooleProcess->pipe, function(){


### PR DESCRIPTION
官方目前支持[Cycwin(屏蔽部分功能)](https://wiki.swoole.com/wiki/page/1050.html)，但是不排除部分开发者临时需要在win开发项目。目前发现只需要修改小部门代码即可在es中跑起（目前仅发现不支持cli_set_process_title()）