### PR TITLE
通过GroupNameString调用kill方法，没有直接获取到PID

### DIFF
--- a/src/Process/Manager.php
+++ b/src/Process/Manager.php
@@ -49,7 +49,7 @@ class Manager
         }else{
             foreach ($this->table as $key => $value){
                 if($value['group'] == $pidOrGroupName){
-                    $list[$key] = $value;
+                    $list[$key] = $value['pid'];
                 }
             }
         }


### PR DESCRIPTION
[debug][warning]:[Swoole\Process::kill() expects parameter 1 to be int, array given at file:/xxx/vendor/easyswoole/component/src/Process/Manager.php line:58